### PR TITLE
Init changes

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -1,4 +1,4 @@
-
+﻿
 Description:
 
     The 51Degrees Java API is designed to be easy and quick to deploy and use even for 
@@ -56,6 +56,22 @@ This project uses SLF4J, using the MIT licence.
 http://www.slf4j.org/license.html
 
 --------------------------------------------------------------------------------
+Version 3.1.8.
+Changes:
+
+Added several methods to preload data on the Dataset object:
+  initSignatures()
+  initNodes()
+  initProfiles()
+  initComponents()
+  initProperties()
+  initValues()
+  initSignatureRanks()
+  
+Added iterators classes, StreamVariableListIterator and StreamFixedListIterator.
+These fixed a NotSupportedOperation exception on some Dataset collections when
+created with a StreamFactory.
+
 Version 3.1.7.2
 Changes:
 

--- a/src/core/fiftyone/mobile/detection/Dataset.java
+++ b/src/core/fiftyone/mobile/detection/Dataset.java
@@ -506,29 +506,13 @@ public class Dataset implements Disposable {
         format = strings.get(formatOffset).toString();
         copyright = strings.get(copyrightOffset).toString();
 
-        // Initialise any objects that can be pre referenced to speed up
-        // initial matching.
-        for (Signature signature : signatures) {
-            signature.init();
-        }
-        for (Node node : nodes) {
-            node.init();
-        }
-        for (Profile profile : profiles) {
-            profile.init();
-        }
-        for (Component component : getComponents()) {
-            component.init();
-        }
-        for (Property property : getProperties()) {
-            property.init();
-        }
-        for (Value value : values) {
-            value.init();
-        }
-        for (RankedSignatureIndex rsi : rankedSignatureIndexes) {
-            rsi.init();
-        }
+        initSignatures();
+        initNodes();
+        initProfiles();
+        initComponents();
+        initProperties();
+        initValues();
+        initSignatureRanks();
 
         // We no longer need the strings data structure as all dependent
         // data has been taken from it.
@@ -539,6 +523,78 @@ public class Dataset implements Disposable {
         // components and signatures.
         profiles.dispose();
         profiles = null;
+    }
+
+    /**
+     * Preloads signatures to speed retrieval later at the expense of memory.
+     * This method doesn't need to be used if init() has already been called.
+     */
+    public void initSignatures() throws IOException {
+        // Initialise any objects that can be pre referenced to speed up
+        // initial matching.
+        for (Signature signature : signatures) {
+            signature.init();
+        }
+    }
+
+    /**
+     * Preloads nodes to speed retrieval later at the expense of memory.
+     * This method doesn't need to be used if init() has already been called.
+     */
+    public void initNodes() throws IOException {
+        for (Node node : nodes) {
+            node.init();
+        }
+    }
+
+    /**
+     * Preloads profiles to speed retrieval later at the expense of memory.
+     * This method doesn't need to be used if init() has already been called.
+     */
+    public void initProfiles() throws IOException {
+        for (Profile profile : profiles) {
+            profile.init();
+        }
+    }
+
+    /**
+     * Preloads components to speed retrieval later at the expense of memory.
+     * This method doesn't need to be used if init() has already been called.
+     */
+    public void initComponents() throws IOException {
+        for (Component component : getComponents()) {
+            component.init();
+        }
+    }
+
+    /**
+     * Preloads properties to speed retrieval later at the expense of memory.
+     * This method doesn't need to be used if init() has already been called.
+     */
+    public void initProperties() throws IOException {
+        for (Property property : getProperties()) {
+            property.init();
+        }
+    }
+
+    /**
+     * Preloads values to speed retrieval later at the expense of memory.
+     * This method doesn't need to be used if init() has already been called.
+     */
+    public void initValues() throws IOException {
+        for (Value value : values) {
+            value.init();
+        }
+    }
+
+    /**
+     * Preloads signature ranks to speed retrieval later at the expense of memory.
+     * This method doesn't need to be used if init() has already been called.
+     */
+    public void initSignatureRanks() throws IOException {
+        for (RankedSignatureIndex rsi : rankedSignatureIndexes) {
+            rsi.init();
+        }
     }
 
     /**

--- a/src/core/fiftyone/mobile/detection/entities/stream/Source.java
+++ b/src/core/fiftyone/mobile/detection/entities/stream/Source.java
@@ -63,9 +63,9 @@ public class Source implements Disposable {
             }
         }
         if(channel != null) {
-         try {
-             channel.close();
-         }
+            try {
+               channel.close();
+            }
          catch(IOException ex){}
         }
     }

--- a/src/core/fiftyone/mobile/detection/entities/stream/StreamFixedList.java
+++ b/src/core/fiftyone/mobile/detection/entities/stream/StreamFixedList.java
@@ -79,6 +79,6 @@ public class StreamFixedList<T extends BaseEntity> extends BaseList<T> {
 
     @Override
     public Iterator<T> iterator() {
-        throw new UnsupportedOperationException();
+        return new StreamFixedListIterator<T>(this);
     }
 }

--- a/src/core/fiftyone/mobile/detection/entities/stream/StreamFixedListIterator.java
+++ b/src/core/fiftyone/mobile/detection/entities/stream/StreamFixedListIterator.java
@@ -1,0 +1,84 @@
+package fiftyone.mobile.detection.entities.stream;
+
+import fiftyone.mobile.detection.entities.BaseEntity;
+import java.io.IOException;
+import java.util.Iterator;
+
+/* *********************************************************************
+ * This Source Code Form is copyright of 51Degrees Mobile Experts Limited. 
+ * Copyright 2014 51Degrees Mobile Experts Limited, 5 Charlotte Close,
+ * Caversham, Reading, Berkshire, United Kingdom RG4 7BY
+ * 
+ * This Source Code Form is the subject of the following patent 
+ * applications, owned by 51Degrees Mobile Experts Limited of 5 Charlotte
+ * Close, Caversham, Reading, Berkshire, United Kingdom RG4 7BY: 
+ * European Patent Application No. 13192291.6; and 
+ * United States Patent Application Nos. 14/085,223 and 14/085,301.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0.
+ * 
+ * If a copy of the MPL was not distributed with this file, You can obtain
+ * one at http://mozilla.org/MPL/2.0/.
+ * 
+ * This Source Code Form is "Incompatible With Secondary Licenses", as
+ * defined by the Mozilla Public License, v. 2.0.
+ * ********************************************************************* */
+
+/**
+ * A general class that iterates over entities in StreamVariableLists. The iteration
+ * lazy loads for low memory and quick start retrieval.
+ */
+public class StreamFixedListIterator<T extends BaseEntity> implements Iterator<T> {
+
+    int size;
+    
+    StreamFixedList<T> fixedList;
+    
+    int index;
+    
+    /**
+     * Constructs the StreamFixedListIterator.
+     * @param fixedList 
+     */
+    public StreamFixedListIterator(StreamFixedList<T> fixedList)
+    {
+        this.fixedList = fixedList;
+        size = fixedList.size();
+        
+        index = 0;
+    }
+    
+    /**
+     * Gets if there are any more entities in the list.
+     * 
+     * @return true if there are more entities to iterate.
+     */
+    public boolean hasNext() {
+    
+        return index < size;
+    }
+
+    /**
+     * Gets the next entity for retrieval and increments the iteration.
+     * 
+     * @return the next entity in the list.
+     */
+    public T next() {
+        try {
+            T t = fixedList.get(index);
+            index++;
+            return t;
+        }
+        catch(Exception ex) {
+            return null;
+        }
+    }
+
+    /**
+     * remove is not supported.
+     */
+    public void remove() {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/src/core/fiftyone/mobile/detection/entities/stream/StreamFixedListIterator.java
+++ b/src/core/fiftyone/mobile/detection/entities/stream/StreamFixedListIterator.java
@@ -39,12 +39,13 @@ public class StreamFixedListIterator<T extends BaseEntity> implements Iterator<T
     
     /**
      * Constructs the StreamFixedListIterator.
-     * @param fixedList 
+     * 
+     * @param streamFixedList 
      */
-    public StreamFixedListIterator(StreamFixedList<T> fixedList)
+    public StreamFixedListIterator(StreamFixedList<T> streamFixedList)
     {
-        this.fixedList = fixedList;
-        size = fixedList.size();
+        fixedList = streamFixedList;
+        size = streamFixedList.size();
         
         index = 0;
     }

--- a/src/core/fiftyone/mobile/detection/entities/stream/StreamVariableList.java
+++ b/src/core/fiftyone/mobile/detection/entities/stream/StreamVariableList.java
@@ -79,16 +79,6 @@ public class StreamVariableList<T extends BaseEntity> extends BaseList<T> {
 
     @Override
     public Iterator<T> iterator() {
-        try {
-            List<T> result = new ArrayList<T>();
-            for (int offset = 0; offset < header.getLength();) {
-                T entity = get(offset);
-                result.add(entity);
-                offset += entityFactory.getLength(entity);
-            }
-            return result.iterator();
-        } catch (IOException e) {
-            return null;
-        }
+        return new StreamVariableListIterator<T>(this);
     }
 }

--- a/src/core/fiftyone/mobile/detection/entities/stream/StreamVariableListIterator.java
+++ b/src/core/fiftyone/mobile/detection/entities/stream/StreamVariableListIterator.java
@@ -44,7 +44,7 @@ public class StreamVariableListIterator<T extends BaseEntity> implements Iterato
     {
         this.varList = varList;
         size = varList.size();
-        int offset = 0;
+        offset = 0;
         
         index = 0;
     }

--- a/src/core/fiftyone/mobile/detection/entities/stream/StreamVariableListIterator.java
+++ b/src/core/fiftyone/mobile/detection/entities/stream/StreamVariableListIterator.java
@@ -40,10 +40,15 @@ public class StreamVariableListIterator<T extends BaseEntity> implements Iterato
     
     int index;
     
-    public StreamVariableListIterator(StreamVariableList<T> varList)
+    /**
+     * Constructs the StreamVariableListIterator.
+     * 
+     * @param streamVariableList 
+     */
+    public StreamVariableListIterator(StreamVariableList<T> streamVariableList)
     {
-        this.varList = varList;
-        size = varList.size();
+        varList = streamVariableList;
+        size = streamVariableList.size();
         offset = 0;
         
         index = 0;

--- a/src/core/fiftyone/mobile/detection/entities/stream/StreamVariableListIterator.java
+++ b/src/core/fiftyone/mobile/detection/entities/stream/StreamVariableListIterator.java
@@ -33,7 +33,6 @@ import java.util.List;
  */
 public class StreamVariableListIterator<T extends BaseEntity> implements Iterator<T> {
 
-    int entityLength;
     int size;
     int offset;
     
@@ -45,7 +44,6 @@ public class StreamVariableListIterator<T extends BaseEntity> implements Iterato
     {
         this.varList = varList;
         size = varList.size();
-        entityLength = varList.entityFactory.getLength();
         int offset = 0;
         
         index = 0;
@@ -69,7 +67,7 @@ public class StreamVariableListIterator<T extends BaseEntity> implements Iterato
     public T next() {
         try {
             T t = varList.get(offset);
-            offset += entityLength;
+            offset += varList.entityFactory.getLength(t);
             index++;
             return t;
         }

--- a/src/core/fiftyone/mobile/detection/entities/stream/StreamVariableListIterator.java
+++ b/src/core/fiftyone/mobile/detection/entities/stream/StreamVariableListIterator.java
@@ -1,0 +1,84 @@
+package fiftyone.mobile.detection.entities.stream;
+
+import fiftyone.mobile.detection.entities.BaseEntity;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+/* *********************************************************************
+ * This Source Code Form is copyright of 51Degrees Mobile Experts Limited. 
+ * Copyright 2014 51Degrees Mobile Experts Limited, 5 Charlotte Close,
+ * Caversham, Reading, Berkshire, United Kingdom RG4 7BY
+ * 
+ * This Source Code Form is the subject of the following patent 
+ * applications, owned by 51Degrees Mobile Experts Limited of 5 Charlotte
+ * Close, Caversham, Reading, Berkshire, United Kingdom RG4 7BY: 
+ * European Patent Application No. 13192291.6; and 
+ * United States Patent Application Nos. 14/085,223 and 14/085,301.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0.
+ * 
+ * If a copy of the MPL was not distributed with this file, You can obtain
+ * one at http://mozilla.org/MPL/2.0/.
+ * 
+ * This Source Code Form is "Incompatible With Secondary Licenses", as
+ * defined by the Mozilla Public License, v. 2.0.
+ * ********************************************************************* */
+
+/**
+ * A general class that iterates over entities in StreamVariableLists. The iteration
+ * lazy loads for low memory and quick start retrieval.
+ */
+public class StreamVariableListIterator<T extends BaseEntity> implements Iterator<T> {
+
+    int entityLength;
+    int size;
+    int offset;
+    
+    StreamVariableList<T> varList;
+    
+    int index;
+    
+    public StreamVariableListIterator(StreamVariableList<T> varList)
+    {
+        this.varList = varList;
+        size = varList.size();
+        entityLength = varList.entityFactory.getLength();
+        int offset = 0;
+        
+        index = 0;
+    }
+    
+    /**
+     * Gets if there are any more entities in the list.
+     * 
+     * @return true if there are more entities to iterate.
+     */
+    public boolean hasNext() {
+    
+        return index < size;
+    }
+
+    /**
+     * Gets the next entity for retrieval and increments the iteration.
+     * 
+     * @return the next entity in the list.
+     */
+    public T next() {
+        try {
+            T t = varList.get(offset);
+            offset += entityLength;
+            index++;
+            return t;
+        }
+        catch(Exception ex) {
+            return null;
+        }
+    }
+
+    public void remove() {
+        throw new UnsupportedOperationException();
+    }
+}


### PR DESCRIPTION
Made changes to init() so entities can be selectively initialised, speeding up some tasks, such as getting signature ranks. This merge also adds iterators for the streaming lists so they can be looped in a for( : ) loop without throwing.
